### PR TITLE
SC-92 fixed image to fit in mobile and tablet for image carousel

### DIFF
--- a/spire-coffee/src/component/carousel/ImageCarousel.tsx
+++ b/spire-coffee/src/component/carousel/ImageCarousel.tsx
@@ -29,9 +29,10 @@ const ImageCarousel = () => {
         }}
         indicatorContainerProps={{
           style: {
-            marginTop: "1rem",
-            marginBottom: "1rem",
-            position: "relative",
+            position: "absolute",
+            bottom: "10px",
+            left: "50%",
+            transform: "translateX(-50%)",
             zIndex: 1,
           },
         }}
@@ -46,11 +47,25 @@ const ImageCarousel = () => {
             key={index}
             sx={{
               width: "100%",
-              height: "393px",
-              // objectFit: "cover",
+              height: {
+                xs: "275px",
+                sm: "550px",
+                md: "600px",
+                lg: "445px",
+              },
+              position: "relative", 
+              overflow: "hidden",
             }}
           >
-            <img src={item.imagePath} alt={item.imagePath} />
+            <img
+              src={item.imagePath}
+              alt={item.imagePath}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+              }}
+            />
           </Box>
         ))}
       </Carousel>


### PR DESCRIPTION
## Describe your changes (point form)

- Fixed image in mobile and tablet for cafe page image carousel
- From my memory, we care about mobile but thought it would be nice to make the image look nice in tablet as well, can always remove if we dont want it

## Jira Ticket 

[SC-92](https://webdevgang.atlassian.net/browse/SC-92)

## Include any Screenshots/Videos if relevant 

desktop
![image](https://github.com/user-attachments/assets/fba6df2d-fa79-4c7b-bf40-3dfe2df52de3)

tablet
![image](https://github.com/user-attachments/assets/e1b4e9e4-a1b7-4dc7-942e-31945de311d5)

mobile
![image](https://github.com/user-attachments/assets/5cfb5496-166e-45d9-8dfa-8c92e1197271)

## Any other reminders reviewers should know? (`npm i`)

When testing, if you use responsive mode to change the media queries, the carousel gets a little weird

To fix this either:
1. switch the photo to resize the images
2. or refresh the page


[SC-92]: https://webdevgang.atlassian.net/browse/SC-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ